### PR TITLE
Checked for the name when looking for a key in globals.

### DIFF
--- a/javabuilder-parent/javabuilder-core/src/main/java/org/javabuilders/BuilderConfig.java
+++ b/javabuilder-parent/javabuilder-core/src/main/java/org/javabuilders/BuilderConfig.java
@@ -602,7 +602,7 @@ public class BuilderConfig {
 		
 		if (name.matches(GLOBAL_VARIABLE_REGEX)) {
 
-			if (globals.containsKey(globals)) {
+			if (globals.containsKey(name)) {
 				throw new BuildException("A global variable {0} already exists", name); 
 			} else {
 				globals.put(name, value);


### PR DESCRIPTION
I see this is quite an old project but I'm using it regardless and I noticed...

The original code doesn't seem quite correct in that it is checking for the globals as a key of globals and then throwing an exception saying that name doesn't exist.  Checked for name instead.
